### PR TITLE
Fix typos in templates

### DIFF
--- a/.meta.toml
+++ b/.meta.toml
@@ -18,9 +18,6 @@ per-file-ignores = __init__.py:F401
 codespell_extra_lines = """
         exclude: (src/collective/contentsections/static/.*|src/collective/contentsections/distributions/.*.json)
 """
-i18ndude_extra_lines = """
-        pass_filenames: false
-"""
 
 [github]
 jobs = [

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -75,7 +75,6 @@ repos:
     rev: "6.2.1"
     hooks:
     -   id: i18ndude
-        pass_filenames: false
 
 
 ##

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,8 +2,8 @@
 
 ## 2.0.0a3 (unreleased)
 
-
-- Nothing changed yet.
+- Fix typos in card.pt and macros.pt template. [remdub]
+- Enable i18ndude pre-commit checks. [remdub]
 
 
 ## 2.0.0a2 (2025-04-29)

--- a/src/collective/contentsections/sections/contacts/card.pt
+++ b/src/collective/contentsections/sections/contacts/card.pt
@@ -5,7 +5,7 @@
       i18n:domain="collective.contentsections"
 >
   <metal:main fill-slot="main">
-    <metal:core define-macro="content-core">
+    <metal:content-core define-macro="content-core">
       <div class="row row-cols-1 row-cols-md-${context/group_size} g-4">
         <div class="col"
              tal:repeat="item view/items"
@@ -13,38 +13,35 @@
           <div class="card text-center h-100">
             <img class="card-img-top"
                  alt="Lead image"
-                 mt-n4"=""
-                 pe-1=""
                  src="${item/lead_image_url}"
-                 text-end=""
-                 text-white=""
+                 tal:condition="item/lead_image_url"
+                 i18n:attributes="alt"
+            />
+            <div class="text-end text-white pe-1 mt-n4"
                  tal:condition="item/lead_image_caption"
-                 i18n:attributes="alt
-            /&gt;
-            &lt;div class="
-            />${item/lead_image_caption}</div>
-          <div class="card-body">
-            <h4 class="card-title">
-              <span class="d-block">${item/title}</span>
-              <span class="d-block fs-5">${item/subtitle}</span>
-            </h4>
-            <p class="card-text">
-              <a class="d-block"
-                 href="tel:${item/phone}"
-                 tal:condition="item/phone"
-              >${item/phone}</a>
-              <a class="d-block"
-                 href="mailto:${item/email}"
-                 tal:condition="item/email"
-              >${item/email}</a>
-            </p>
-            <p class="card-text"
-               tal:condition="item/description"
-            >${item/description}</p>
+            >${item/lead_image_caption}</div>
+            <div class="card-body">
+              <h4 class="card-title">
+                <span class="d-block">${item/title}</span>
+                <span class="d-block fs-5">${item/subtitle}</span>
+              </h4>
+              <p class="card-text">
+                <a class="d-block"
+                   href="tel:${item/phone}"
+                   tal:condition="item/phone"
+                >${item/phone}</a>
+                <a class="d-block"
+                   href="mailto:${item/email}"
+                   tal:condition="item/email"
+                >${item/email}</a>
+              </p>
+              <p class="card-text"
+                 tal:condition="item/description"
+              >${item/description}</p>
+            </div>
           </div>
         </div>
       </div>
 
-
-    </metal:core></metal:main>
+    </metal:content-core></metal:main>
 </html>

--- a/src/collective/contentsections/views/macros.pt
+++ b/src/collective/contentsections/views/macros.pt
@@ -5,9 +5,7 @@
        alt="Lead image"
        src="${item/lead_image_url}"
        tal:condition="not:context/hide_item_lead_images"
-       tal:attributes="
-         alt;
-       "
+       i18n:attributes="alt"
   />
   <?python
       show_title = not context.hide_item_titles


### PR DESCRIPTION
A major typo was introduced in [this commit](https://github.com/collective/collective.contentsections/commit/511af306d769bae6c363dc2509de6f67c04e2475#diff-49202a5c40536e14ef424ba9cec30db13bd27879e2133d2bcbe16cf18bd742ba) .

This PR fixes this typo. 

It also corrects a i18n:attributes value that was incorreclty set when internationalization support and locales were added.

Finally, it enables the i18n pre-commit checks, which now passes cleanly thanks to the 2 corrections above.