### PR TITLE
Fix zcml includes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 - Add pre-commit to development environment. [remdub]
 - Increase test coverage to 100%. [remdub]
 - Use Select2FieldWidget instead of SelectFieldWidget in ICard. [sverbois]
+- Fix ZCML includes [ale-rt]
 
 
 ## 2.0.0a3 (2025-04-30)

--- a/src/collective/contentsections/configure.zcml
+++ b/src/collective/contentsections/configure.zcml
@@ -9,6 +9,9 @@
   <i18n:registerTranslations directory="locales" />
 
   <include package="Products.CMFPlone" />
+  <include package="collective.geolocationbehavior" />
+  <include package="collective.taxonomy" />
+  <include package="collective.z3cform.datagridfield" />
   <include package="plone.distribution" />
 
   <plone:distribution

--- a/src/collective/contentsections/testing.py
+++ b/src/collective/contentsections/testing.py
@@ -18,9 +18,6 @@ class Layer(PloneSandboxLayer):
         # Load any other ZCML that is required for your tests.
         # The z3c.autoinclude feature is disabled in the Plone fixture base
         # layer.
-        self.loadZCML(package=collective.z3cform.datagridfield)
-        self.loadZCML(package=collective.taxonomy)
-        self.loadZCML(package=collective.geolocationbehavior)
         self.loadZCML(package=collective.contentsections)
 
     def setUpPloneSite(self, portal):


### PR DESCRIPTION
With this patch there is no need to load additional zcml to install this package when ZCML autoinclude is not enabled.